### PR TITLE
fix memory leak when handing empty content request in Http2

### DIFF
--- a/httpserver/src/main/java/esa/httpserver/impl/AggregationHandle.java
+++ b/httpserver/src/main/java/esa/httpserver/impl/AggregationHandle.java
@@ -58,12 +58,10 @@ final class AggregationHandle implements Aggregation {
     }
 
     void appendPartialContent(ByteBuf partialContent) {
-        if (partialContent.isReadable()) {
-            if (content == null) {
-                content = ctx.alloc().compositeBuffer(MAX_COMPOSITE_BUFFER_COMPONENTS);
-            }
-            content.addComponent(true, partialContent);
+        if (content == null) {
+            content = ctx.alloc().compositeBuffer(MAX_COMPOSITE_BUFFER_COMPONENTS);
         }
+        content.addComponent(true, partialContent);
     }
 
     void release() {

--- a/httpserver/src/main/java/esa/httpserver/impl/BaseRequestHandle.java
+++ b/httpserver/src/main/java/esa/httpserver/impl/BaseRequestHandle.java
@@ -230,6 +230,14 @@ abstract class BaseRequestHandle implements RequestHandle {
     public abstract BaseResponse<? extends BaseRequestHandle> response();
 
     void handleContent(ByteBuf buf) {
+        // ignore unreadable data
+        // 1. it is no need to pass empty content to multipart decoder and aggregator
+        // 2.keep the onData() behavior of Http1 and Htt2 consistent, because empty content in
+        //   LastHttpContent#EMPTY_LAST_CONTENT will be ignored in Http1Handler but will be passed in Http2Handler
+        if (!buf.isReadable()) {
+            return;
+        }
+
         if (multipart != null) {
             multipart.onData(buf.duplicate());
         }

--- a/httpserver/src/main/java/esa/httpserver/impl/Http2Handler.java
+++ b/httpserver/src/main/java/esa/httpserver/impl/Http2Handler.java
@@ -184,7 +184,7 @@ final class Http2Handler extends Http2EventAdapter {
         final int readableBytes = data.readableBytes();
 
         // The req.bytes is logically divided to positive one, negative one and zero
-        // 1. The positive one presenting the chunk size left, which mean we can only read num of req.bytes data
+        // 1. The positive one presenting the chunk size left, which means we can only read num of req.bytes data
         //    limited by content length, and the oversize bytes will be discarded.
         // 2. The negative one presenting the num of bytes that we have read, which would be limited by the
         //    ServerOptions#maxContentLength,  and the exceeded bytes will be discarded.


### PR DESCRIPTION
* ignore empty content and do not pass empty content to onData() handler
* add test cases of passing empty data for BaseRequestHandle#handleContent