### PR TITLE
allow to write response in multiple threads in order instead of fixed thread

### DIFF
--- a/httpserver/src/main/java/esa/httpserver/impl/BaseRequestHandle.java
+++ b/httpserver/src/main/java/esa/httpserver/impl/BaseRequestHandle.java
@@ -338,7 +338,7 @@ abstract class BaseRequestHandle implements RequestHandle {
     @Override
     public String toString() {
         return StringUtils.concat("Request",
-                response().isCommitted() ? "![" : "-[",
+                isEnded() ? "![" : "-[",
                 version().name(),
                 " ", rawMethod(),
                 " ", path(),

--- a/httpserver/src/test/java/esa/httpserver/impl/BaseRequestHandleTest.java
+++ b/httpserver/src/test/java/esa/httpserver/impl/BaseRequestHandleTest.java
@@ -415,6 +415,15 @@ class BaseRequestHandleTest {
         assertSame(AggregationHandle.EMPTY, req.aggregated());
     }
 
+    @Test
+    void testToString() {
+        final Req req = plainReq();
+        assertEquals("Request-[HTTP_1_1 GET /foo]", req.toString());
+
+        req.isEnded = true;
+        assertEquals("Request![HTTP_1_1 GET /foo]", req.toString());
+    }
+
     static Req plainReq() {
         return new Req(new EmbeddedChannel(new ChannelInboundHandlerAdapter()).pipeline().firstContext(), "/foo");
     }

--- a/httpserver/src/test/java/esa/httpserver/impl/Http1ResponseImplTest.java
+++ b/httpserver/src/test/java/esa/httpserver/impl/Http1ResponseImplTest.java
@@ -62,7 +62,7 @@ class Http1ResponseImplTest {
         final ResTuple r = newResponse();
         final Http1ResponseImpl res = r.res;
         final AtomicBoolean committed = new AtomicBoolean();
-        final Thread t = new Thread(() -> committed.set(res.ensureCommittedExclusively()), "base-response-test");
+        final Thread t = new Thread(() -> committed.set(res.ensureCommitExclusively()), "base-response-test");
         t.start();
         t.join();
         assertTrue(committed.get());
@@ -73,7 +73,7 @@ class Http1ResponseImplTest {
     void testChunkWriteIfResponseHasBeenEnded() {
         final ResTuple r = newResponse();
         final Http1ResponseImpl res = r.res;
-        assertTrue(res.ensureEndedExclusively());
+        assertTrue(res.ensureEndExclusively(true));
         assertThrows(IllegalStateException.class, () -> res.write(Unpooled.copiedBuffer("foo".getBytes())));
     }
 

--- a/httpserver/src/test/java/esa/httpserver/impl/Http2ResponseImplTest.java
+++ b/httpserver/src/test/java/esa/httpserver/impl/Http2ResponseImplTest.java
@@ -77,7 +77,7 @@ class Http2ResponseImplTest {
         final ResTuple r = newResponse();
         final Http2ResponseImpl res = r.res;
         final AtomicBoolean committed = new AtomicBoolean();
-        final Thread t = new Thread(() -> committed.set(res.ensureCommittedExclusively()), "base-response-test");
+        final Thread t = new Thread(() -> committed.set(res.ensureCommitExclusively()), "base-response-test");
         t.start();
         t.join();
         assertTrue(committed.get());
@@ -88,7 +88,7 @@ class Http2ResponseImplTest {
     void testChunkWriteIfResponseHasBeenEnded() {
         final ResTuple r = newResponse();
         final Http2ResponseImpl res = r.res;
-        assertTrue(res.ensureEndedExclusively());
+        assertTrue(res.ensureEndExclusively(true));
         assertThrows(IllegalStateException.class, () -> res.write(Unpooled.copiedBuffer("foo".getBytes())));
     }
 


### PR DESCRIPTION
* use one filed(BaseResponse#commited) to indicate the status of response
* reomve the committed status check in BaseResponse#setStatus(int)
* optimize toString() method